### PR TITLE
Implement handle_underflow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(core, collections, nonzero, box_raw, iter_order, collections_bound)]
+#![feature(core, collections, nonzero, collections_bound)]
 #![feature(alloc, heap_api, core_intrinsics)]
 
 // This is an attempt at an implementation following the ideal


### PR DESCRIPTION
I tried to finish your work on a `handle_underflow` function in order to get a working version of `BTreeMap::remove`. All tests are passing now.
This pull request also contains another completely unrelated commit that removes feature gates for recently stabilized features.
